### PR TITLE
Fixed plugin to not unlock placeholders in bank

### DIFF
--- a/src/net/runelite/client/plugins/bronzeman/BronzemanPlugin.java
+++ b/src/net/runelite/client/plugins/bronzeman/BronzemanPlugin.java
@@ -84,6 +84,7 @@ public class BronzemanPlugin extends Plugin {
         for (Item i : e.getItemContainer().getItems()) {
             if (i == null) continue;
             if (i.getId() <= 1) continue;
+            if (i.getQuantity() <= 0) continue;    
             if (!unlockedItems.contains(i.getId())) {
                 queueItemUnlock(i.getId());
             }


### PR DESCRIPTION
Fixed bug that would add empty item placeholders in the bank as an unlock. Now players who wish to keep their bank organized and start a fresh without getting rid of placeholders can.